### PR TITLE
Add dynamic Prometheus datasource selection to dashboard

### DIFF
--- a/grafana-dashboards/voi-relaynode-dashboard.json
+++ b/grafana-dashboards/voi-relaynode-dashboard.json
@@ -1,4 +1,14 @@
 {
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS_LOCAL",
+      "label": "Prometheus_LOCAL",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
   "annotations": {
     "list": [
       {
@@ -46,7 +56,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "da74e314-ab7d-49c2-bbdd-44b4d1477a3d"
+        "uid": "${DS_PROMETHEUS_LOCAL}"
       },
       "fieldConfig": {
         "defaults": {
@@ -101,7 +111,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "da74e314-ab7d-49c2-bbdd-44b4d1477a3d"
+            "uid": "${DS_PROMETHEUS_LOCAL}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -121,7 +131,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "da74e314-ab7d-49c2-bbdd-44b4d1477a3d"
+        "uid": "${DS_PROMETHEUS_LOCAL}"
       },
       "fieldConfig": {
         "defaults": {
@@ -204,7 +214,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "da74e314-ab7d-49c2-bbdd-44b4d1477a3d"
+            "uid": "${DS_PROMETHEUS_LOCAL}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -224,7 +234,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "da74e314-ab7d-49c2-bbdd-44b4d1477a3d"
+        "uid": "${DS_PROMETHEUS_LOCAL}"
       },
       "fieldConfig": {
         "defaults": {
@@ -272,7 +282,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "da74e314-ab7d-49c2-bbdd-44b4d1477a3d"
+            "uid": "${DS_PROMETHEUS_LOCAL}"
           },
           "disableTextWrap": false,
           "editorMode": "code",
@@ -292,7 +302,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "da74e314-ab7d-49c2-bbdd-44b4d1477a3d"
+        "uid": "${DS_PROMETHEUS_LOCAL}"
       },
       "fieldConfig": {
         "defaults": {
@@ -340,7 +350,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "da74e314-ab7d-49c2-bbdd-44b4d1477a3d"
+            "uid": "${DS_PROMETHEUS_LOCAL}"
           },
           "disableTextWrap": false,
           "editorMode": "code",
@@ -360,7 +370,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "da74e314-ab7d-49c2-bbdd-44b4d1477a3d"
+        "uid": "${DS_PROMETHEUS_LOCAL}"
       },
       "fieldConfig": {
         "defaults": {
@@ -407,7 +417,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "da74e314-ab7d-49c2-bbdd-44b4d1477a3d"
+            "uid": "${DS_PROMETHEUS_LOCAL}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -427,7 +437,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "da74e314-ab7d-49c2-bbdd-44b4d1477a3d"
+        "uid": "${DS_PROMETHEUS_LOCAL}"
       },
       "fieldConfig": {
         "defaults": {
@@ -510,7 +520,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "da74e314-ab7d-49c2-bbdd-44b4d1477a3d"
+            "uid": "${DS_PROMETHEUS_LOCAL}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -530,7 +540,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "da74e314-ab7d-49c2-bbdd-44b4d1477a3d"
+        "uid": "${DS_PROMETHEUS_LOCAL}"
       },
       "fieldConfig": {
         "defaults": {
@@ -614,7 +624,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "da74e314-ab7d-49c2-bbdd-44b4d1477a3d"
+            "uid": "${DS_PROMETHEUS_LOCAL}"
           },
           "disableTextWrap": false,
           "editorMode": "code",
@@ -635,7 +645,7 @@
       "collapsed": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "da74e314-ab7d-49c2-bbdd-44b4d1477a3d"
+        "uid": "${DS_PROMETHEUS_LOCAL}"
       },
       "gridPos": {
         "h": 1,
@@ -649,7 +659,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "da74e314-ab7d-49c2-bbdd-44b4d1477a3d"
+            "uid": "${DS_PROMETHEUS_LOCAL}"
           },
           "refId": "A"
         }
@@ -660,7 +670,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "da74e314-ab7d-49c2-bbdd-44b4d1477a3d"
+        "uid": "${DS_PROMETHEUS_LOCAL}"
       },
       "description": "Core node uptime",
       "fieldConfig": {
@@ -734,7 +744,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "da74e314-ab7d-49c2-bbdd-44b4d1477a3d"
+            "uid": "${DS_PROMETHEUS_LOCAL}"
           },
           "exemplar": false,
           "expr": "sum(time() - node_boot_time_seconds{instance=\"$instance\"})",
@@ -754,7 +764,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "da74e314-ab7d-49c2-bbdd-44b4d1477a3d"
+        "uid": "${DS_PROMETHEUS_LOCAL}"
       },
       "description": "",
       "fieldConfig": {
@@ -820,7 +830,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "da74e314-ab7d-49c2-bbdd-44b4d1477a3d"
+            "uid": "${DS_PROMETHEUS_LOCAL}"
           },
           "exemplar": false,
           "expr": "count(count(node_cpu_seconds_total{instance=~\"$instance\", mode='system'}) by (cpu))",
@@ -839,7 +849,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "da74e314-ab7d-49c2-bbdd-44b4d1477a3d"
+        "uid": "${DS_PROMETHEUS_LOCAL}"
       },
       "description": "",
       "fieldConfig": {
@@ -904,7 +914,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "da74e314-ab7d-49c2-bbdd-44b4d1477a3d"
+            "uid": "${DS_PROMETHEUS_LOCAL}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -918,7 +928,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "da74e314-ab7d-49c2-bbdd-44b4d1477a3d"
+            "uid": "${DS_PROMETHEUS_LOCAL}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -932,7 +942,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "da74e314-ab7d-49c2-bbdd-44b4d1477a3d"
+            "uid": "${DS_PROMETHEUS_LOCAL}"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -950,7 +960,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "da74e314-ab7d-49c2-bbdd-44b4d1477a3d"
+        "uid": "${DS_PROMETHEUS_LOCAL}"
       },
       "description": "",
       "fieldConfig": {
@@ -1012,7 +1022,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "da74e314-ab7d-49c2-bbdd-44b4d1477a3d"
+            "uid": "${DS_PROMETHEUS_LOCAL}"
           },
           "exemplar": true,
           "expr": "node_filefd_allocated{instance=~\"$instance\"}",
@@ -1031,7 +1041,7 @@
       "columns": [],
       "datasource": {
         "type": "prometheus",
-        "uid": "da74e314-ab7d-49c2-bbdd-44b4d1477a3d"
+        "uid": "${DS_PROMETHEUS_LOCAL}"
       },
       "fontSize": "120%",
       "gridPos": {
@@ -1176,7 +1186,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "da74e314-ab7d-49c2-bbdd-44b4d1477a3d"
+            "uid": "${DS_PROMETHEUS_LOCAL}"
           },
           "exemplar": false,
           "expr": "node_filesystem_size_bytes{instance=~'$instance',fstype=~\"ext4|xfs\"}",
@@ -1191,7 +1201,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "da74e314-ab7d-49c2-bbdd-44b4d1477a3d"
+            "uid": "${DS_PROMETHEUS_LOCAL}"
           },
           "exemplar": false,
           "expr": "node_filesystem_avail_bytes {instance=~'$instance',fstype=~\"ext4|xfs\"}",
@@ -1206,7 +1216,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "da74e314-ab7d-49c2-bbdd-44b4d1477a3d"
+            "uid": "${DS_PROMETHEUS_LOCAL}"
           },
           "exemplar": false,
           "expr": "1-(node_filesystem_free_bytes{instance=~'$instance',fstype=~\"ext4|xfs\"} / node_filesystem_size_bytes{instance=~'$instance',fstype=~\"ext4|xfs\"})",
@@ -1221,7 +1231,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "da74e314-ab7d-49c2-bbdd-44b4d1477a3d"
+            "uid": "${DS_PROMETHEUS_LOCAL}"
           },
           "expr": "",
           "format": "table",
@@ -1238,7 +1248,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "da74e314-ab7d-49c2-bbdd-44b4d1477a3d"
+        "uid": "${DS_PROMETHEUS_LOCAL}"
       },
       "description": "",
       "fieldConfig": {
@@ -1300,7 +1310,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "da74e314-ab7d-49c2-bbdd-44b4d1477a3d"
+            "uid": "${DS_PROMETHEUS_LOCAL}"
           },
           "exemplar": false,
           "expr": "node_memory_MemTotal_bytes{instance=~\"$instance\"}",
@@ -1323,7 +1333,7 @@
       "dashes": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "da74e314-ab7d-49c2-bbdd-44b4d1477a3d"
+        "uid": "${DS_PROMETHEUS_LOCAL}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1392,7 +1402,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "da74e314-ab7d-49c2-bbdd-44b4d1477a3d"
+            "uid": "${DS_PROMETHEUS_LOCAL}"
           },
           "exemplar": true,
           "expr": "node_load1{instance=~\"$instance\"}*100",
@@ -1406,7 +1416,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "da74e314-ab7d-49c2-bbdd-44b4d1477a3d"
+            "uid": "${DS_PROMETHEUS_LOCAL}"
           },
           "exemplar": true,
           "expr": "node_load5{instance=~\"$instance\"}*100",
@@ -1420,7 +1430,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "da74e314-ab7d-49c2-bbdd-44b4d1477a3d"
+            "uid": "${DS_PROMETHEUS_LOCAL}"
           },
           "exemplar": true,
           "expr": "node_load15{instance=~\"$instance\"}*100",
@@ -1523,7 +1533,7 @@
       "dashes": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "da74e314-ab7d-49c2-bbdd-44b4d1477a3d"
+        "uid": "${DS_PROMETHEUS_LOCAL}"
       },
       "decimals": 2,
       "description": "node_disk_io_time_seconds_total：\nThe number of milliseconds the disk spends on input/output operations. This value is the accumulated value.（Milliseconds Spent Doing I/Os）\n\nirate(node_disk_io_time_seconds_total[1m])：\nCalculate the rate per second: (last value - last previous value) / timestamp difference, that is, the percentage of time that the disk spends on I/O operations in 1 second.",
@@ -1572,7 +1582,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "da74e314-ab7d-49c2-bbdd-44b4d1477a3d"
+            "uid": "${DS_PROMETHEUS_LOCAL}"
           },
           "exemplar": true,
           "expr": "avg(irate(node_cpu_seconds_total{instance=~\"$instance\",mode=\"system\"}[1m]))",
@@ -1587,7 +1597,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "da74e314-ab7d-49c2-bbdd-44b4d1477a3d"
+            "uid": "${DS_PROMETHEUS_LOCAL}"
           },
           "exemplar": true,
           "expr": "avg(irate(node_cpu_seconds_total{instance=~\"$instance\",mode=\"user\"}[1m]))",
@@ -1601,7 +1611,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "da74e314-ab7d-49c2-bbdd-44b4d1477a3d"
+            "uid": "${DS_PROMETHEUS_LOCAL}"
           },
           "exemplar": true,
           "expr": "avg(irate(node_cpu_seconds_total{instance=~\"$instance\",mode=\"idle\"}[1m]))",
@@ -1616,7 +1626,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "da74e314-ab7d-49c2-bbdd-44b4d1477a3d"
+            "uid": "${DS_PROMETHEUS_LOCAL}"
           },
           "exemplar": true,
           "expr": "avg(irate(node_cpu_seconds_total{instance=~\"$instance\",mode=\"iowait\"}[1m]))",
@@ -1630,7 +1640,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "da74e314-ab7d-49c2-bbdd-44b4d1477a3d"
+            "uid": "${DS_PROMETHEUS_LOCAL}"
           },
           "exemplar": true,
           "expr": "irate(node_disk_io_time_seconds_total{instance=~\"$instance\"}[1m])",
@@ -1643,7 +1653,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "da74e314-ab7d-49c2-bbdd-44b4d1477a3d"
+            "uid": "${DS_PROMETHEUS_LOCAL}"
           },
           "exemplar": true,
           "expr": "avg(irate(node_cpu_seconds_total{mode=\"system\"}[1m]))",
@@ -1703,7 +1713,7 @@
       "dashes": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "da74e314-ab7d-49c2-bbdd-44b4d1477a3d"
+        "uid": "${DS_PROMETHEUS_LOCAL}"
       },
       "description": "Reads completed: Reads per second per disk partition\n\nWrites completed: Number of writes per second per disk partition\n\nIO now Number of input/output requests being processed per disk partition per second",
       "fill": 2,
@@ -1755,7 +1765,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "da74e314-ab7d-49c2-bbdd-44b4d1477a3d"
+            "uid": "${DS_PROMETHEUS_LOCAL}"
           },
           "exemplar": true,
           "expr": "irate(node_disk_reads_completed_total{instance=~\"$instance\"}[1m])",
@@ -1770,7 +1780,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "da74e314-ab7d-49c2-bbdd-44b4d1477a3d"
+            "uid": "${DS_PROMETHEUS_LOCAL}"
           },
           "exemplar": true,
           "expr": "irate(node_disk_writes_completed_total{instance=~\"$instance\"}[1m])",
@@ -1785,7 +1795,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "da74e314-ab7d-49c2-bbdd-44b4d1477a3d"
+            "uid": "${DS_PROMETHEUS_LOCAL}"
           },
           "exemplar": true,
           "expr": "node_disk_io_now{instance=~\"$instance\"}",
@@ -1837,7 +1847,7 @@
       "dashes": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "da74e314-ab7d-49c2-bbdd-44b4d1477a3d"
+        "uid": "${DS_PROMETHEUS_LOCAL}"
       },
       "description": "Read bytes The number of bits read per second per disk partition\nWritten bytes The number of bits written per second per disk partition",
       "fill": 2,
@@ -1890,7 +1900,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "da74e314-ab7d-49c2-bbdd-44b4d1477a3d"
+            "uid": "${DS_PROMETHEUS_LOCAL}"
           },
           "exemplar": true,
           "expr": "irate(node_disk_read_bytes_total{instance=~\"$instance\"}[1m])",
@@ -1904,7 +1914,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "da74e314-ab7d-49c2-bbdd-44b4d1477a3d"
+            "uid": "${DS_PROMETHEUS_LOCAL}"
           },
           "exemplar": true,
           "expr": "irate(node_disk_written_bytes_total{instance=~\"$instance\"}[1m])",
@@ -1959,7 +1969,7 @@
       "dashes": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "da74e314-ab7d-49c2-bbdd-44b4d1477a3d"
+        "uid": "${DS_PROMETHEUS_LOCAL}"
       },
       "description": "Read time ms Number of seconds per disk partition read operation\n\nWrite time ms Number of seconds spent per disk partition write operation\n\nIO time ms Number of seconds spent per disk partition input/output operation\n\n IO time weighted Weighted seconds spent per disk partition input/output operation",
       "fill": 3,
@@ -2011,7 +2021,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "da74e314-ab7d-49c2-bbdd-44b4d1477a3d"
+            "uid": "${DS_PROMETHEUS_LOCAL}"
           },
           "exemplar": true,
           "expr": "irate(node_disk_io_time_seconds_total{instance=~\"$instance\"}[1m])",
@@ -2026,7 +2036,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "da74e314-ab7d-49c2-bbdd-44b4d1477a3d"
+            "uid": "${DS_PROMETHEUS_LOCAL}"
           },
           "exemplar": true,
           "expr": "irate(node_disk_io_time_weighted_seconds_total{instance=~\"$instance\"}[1m])",
@@ -2040,7 +2050,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "da74e314-ab7d-49c2-bbdd-44b4d1477a3d"
+            "uid": "${DS_PROMETHEUS_LOCAL}"
           },
           "exemplar": true,
           "expr": "irate(node_disk_read_time_seconds_total{instance=~\"$instance\"}[1m])",
@@ -2054,7 +2064,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "da74e314-ab7d-49c2-bbdd-44b4d1477a3d"
+            "uid": "${DS_PROMETHEUS_LOCAL}"
           },
           "exemplar": true,
           "expr": "irate(node_disk_write_time_seconds_total{instance=~\"$instance\"}[1m])",
@@ -2104,7 +2114,7 @@
       "dashes": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "da74e314-ab7d-49c2-bbdd-44b4d1477a3d"
+        "uid": "${DS_PROMETHEUS_LOCAL}"
       },
       "fill": 1,
       "fillGradient": 0,
@@ -2155,7 +2165,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "da74e314-ab7d-49c2-bbdd-44b4d1477a3d"
+            "uid": "${DS_PROMETHEUS_LOCAL}"
           },
           "exemplar": true,
           "expr": "irate(node_network_receive_bytes_total{instance=~'$instance',device!~'tap.*'}[5m])*8",
@@ -2169,7 +2179,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "da74e314-ab7d-49c2-bbdd-44b4d1477a3d"
+            "uid": "${DS_PROMETHEUS_LOCAL}"
           },
           "exemplar": true,
           "expr": "irate(node_network_transmit_bytes_total{instance=~'$instance',device!~'tap.*'}[5m])*8",
@@ -2221,7 +2231,7 @@
       "dashes": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "da74e314-ab7d-49c2-bbdd-44b4d1477a3d"
+        "uid": "${DS_PROMETHEUS_LOCAL}"
       },
       "description": "CurrEstab - TCP connections with current state ESTABLISHED or CLOSE-WAIT\n\nActiveOpens - TCP average connections that have been converted from CLOSED state to SYN-SENT state (within 1 minute)\n\nPassiveOpens - Directly from LISTEN state The average number of TCP connections to SYN-RCVD state (within 1 minute)\n\nTCP_all oc - the number of TCP sockets allocated (established, applied to sk_buff)\n\nTCP_inuse - in use (listening The number of TCP sockets \n\nTCP_tw - the number of TCP connections waiting to be closed",
       "fill": 0,
@@ -2267,7 +2277,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "da74e314-ab7d-49c2-bbdd-44b4d1477a3d"
+            "uid": "${DS_PROMETHEUS_LOCAL}"
           },
           "exemplar": true,
           "expr": "node_netstat_Tcp_CurrEstab{instance=~'$instance'}",
@@ -2282,7 +2292,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "da74e314-ab7d-49c2-bbdd-44b4d1477a3d"
+            "uid": "${DS_PROMETHEUS_LOCAL}"
           },
           "exemplar": true,
           "expr": "node_sockstat_TCP_tw{instance=~'$instance'}",
@@ -2295,7 +2305,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "da74e314-ab7d-49c2-bbdd-44b4d1477a3d"
+            "uid": "${DS_PROMETHEUS_LOCAL}"
           },
           "exemplar": true,
           "expr": "irate(node_netstat_Tcp_ActiveOpens{instance=~'$instance'}[1m])",
@@ -2309,7 +2319,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "da74e314-ab7d-49c2-bbdd-44b4d1477a3d"
+            "uid": "${DS_PROMETHEUS_LOCAL}"
           },
           "exemplar": true,
           "expr": "irate(node_netstat_Tcp_PassiveOpens{instance=~'$instance'}[1m])",
@@ -2322,7 +2332,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "da74e314-ab7d-49c2-bbdd-44b4d1477a3d"
+            "uid": "${DS_PROMETHEUS_LOCAL}"
           },
           "exemplar": true,
           "expr": "node_sockstat_TCP_alloc{instance=~'$instance'}",
@@ -2335,7 +2345,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "da74e314-ab7d-49c2-bbdd-44b4d1477a3d"
+            "uid": "${DS_PROMETHEUS_LOCAL}"
           },
           "exemplar": true,
           "expr": "node_sockstat_TCP_inuse{instance=~'$instance'}",
@@ -2396,7 +2406,7 @@
         },
         "datasource": {
           "type": "prometheus",
-          "uid": "da74e314-ab7d-49c2-bbdd-44b4d1477a3d"
+          "uid": "${DS_PROMETHEUS_LOCAL}"
         },
         "definition": "label_values(node_memory_MemTotal_bytes, instance)",
         "hide": 0,


### PR DESCRIPTION
## Enable Dynamic Prometheus Datasource Selection

This pull request replaces hardcoded Prometheus datasource UIDs with a variable (`DS_PROMETHEUS_LOCAL`) allowing users to select their datasource upon importing the dashboard. This change eliminates import errors related to missing datasources and improves adaptability across different Grafana setups.

### Error with hardcoded UID
![before-changes](https://github.com/user-attachments/assets/adf1b058-6b00-46c7-a65b-676b90575423)

### Dashboard import screen with datasource selection
![after-changes](https://github.com/user-attachments/assets/633ee5a2-d3da-44a9-ba95-c55c33566e34)

